### PR TITLE
Add unique/drop index support

### DIFF
--- a/test/ast_parser_test.exs
+++ b/test/ast_parser_test.exs
@@ -153,6 +153,52 @@ defmodule ExcellentMigrations.AstParserTest do
     assert [] == AstParser.parse(ast_conc_true)
   end
 
+  test "detects unique index added not concurrently" do
+    ast_single = string_to_ast("create unique_index(:dumplings, :dough)")
+    ast_single_with_opts = string_to_ast("create unique_index(:dumplings, :dough, unique: true)")
+    ast_multi = string_to_ast("create unique_index(:dumplings, [:dough])")
+    ast_multi_with_opts = string_to_ast("create unique_index(:dumplings, [:dough], unique: true)")
+
+    ast_conc_false =
+      string_to_ast("create unique_index(:dumplings, [:dough], concurrently: false)")
+
+    ast_conc_true = string_to_ast("create unique_index(:dumplings, [:dough], concurrently: true)")
+
+    assert [index_not_concurrently: 1] == AstParser.parse(ast_single)
+    assert [index_not_concurrently: 1] == AstParser.parse(ast_single_with_opts)
+    assert [index_not_concurrently: 1] == AstParser.parse(ast_multi)
+    assert [index_not_concurrently: 1] == AstParser.parse(ast_multi_with_opts)
+    assert [index_not_concurrently: 1] == AstParser.parse(ast_conc_false)
+    assert [] == AstParser.parse(ast_conc_true)
+  end
+
+  test "detects unique index added not concurrently using if not exists" do
+    ast_single = string_to_ast("create_if_not_exists unique_index(:dumplings, :dough)")
+
+    ast_single_with_opts =
+      string_to_ast("create_if_not_exists unique_index(:dumplings, :dough, unique: true)")
+
+    ast_multi = string_to_ast("create_if_not_exists unique_index(:dumplings, [:dough])")
+
+    ast_multi_with_opts =
+      string_to_ast("create_if_not_exists unique_index(:dumplings, [:dough], unique: true)")
+
+    ast_conc_false =
+      string_to_ast(
+        "create_if_not_exists unique_index(:dumplings, [:dough], concurrently: false)"
+      )
+
+    ast_conc_true =
+      string_to_ast("create_if_not_exists unique_index(:dumplings, [:dough], concurrently: true)")
+
+    assert [index_not_concurrently: 1] == AstParser.parse(ast_single)
+    assert [index_not_concurrently: 1] == AstParser.parse(ast_single_with_opts)
+    assert [index_not_concurrently: 1] == AstParser.parse(ast_multi)
+    assert [index_not_concurrently: 1] == AstParser.parse(ast_multi_with_opts)
+    assert [index_not_concurrently: 1] == AstParser.parse(ast_conc_false)
+    assert [] == AstParser.parse(ast_conc_true)
+  end
+
   test "detects index with too many columns" do
     ast_too_many_not_concurrently =
       string_to_ast("create index(\"ingredients\", [:a, :b, :c, :d])")

--- a/test/example_migrations/20220725111000_create_index.exs
+++ b/test/example_migrations/20220725111000_create_index.exs
@@ -1,0 +1,11 @@
+defmodule ExcellentMigrations.CreateIndex do
+  def up do
+    create(index(:dumplings, [:dough]))
+    create_if_not_exists(index(:dumplings, [:dough]))
+  end
+
+  def down do
+    drop(index(:dumplings, [:dough]))
+    drop_if_exists(index(:dumplings, [:dough]))
+  end
+end

--- a/test/example_migrations/20220725111501_create_unique_index.exs
+++ b/test/example_migrations/20220725111501_create_unique_index.exs
@@ -1,0 +1,11 @@
+defmodule ExcellentMigrations.CreateUniqueIndex do
+  def up do
+    create(unique_index(:dumplings, [:dough]))
+    create_if_not_exists(unique_index(:dumplings, [:dough]))
+  end
+
+  def down do
+    drop(unique_index(:dumplings, [:dough]))
+    drop_if_exists(unique_index(:dumplings, [:dough]))
+  end
+end

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -11,7 +11,9 @@ defmodule ExcellentMigrations.RunnerTest do
       "test/example_migrations/20191026103005_remove_column.exs",
       "test/example_migrations/20191026103006_rename_table.exs",
       "test/example_migrations/20191026103007_add_column_with_default_value.exs",
-      "test/example_migrations/20191026103008_change_column_type.exs"
+      "test/example_migrations/20191026103008_change_column_type.exs",
+      "test/example_migrations/20220725111000_create_index.exs",
+      "test/example_migrations/20220725111501_create_unique_index.exs"
     ]
 
     assert {
@@ -56,6 +58,46 @@ defmodule ExcellentMigrations.RunnerTest do
                  line: 4,
                  path: "test/example_migrations/20191026103008_change_column_type.exs",
                  type: :column_type_changed
+               },
+               %{
+                 line: 3,
+                 path: "test/example_migrations/20220725111000_create_index.exs",
+                 type: :index_not_concurrently
+               },
+               %{
+                 line: 4,
+                 path: "test/example_migrations/20220725111000_create_index.exs",
+                 type: :index_not_concurrently
+               },
+               %{
+                 line: 8,
+                 path: "test/example_migrations/20220725111000_create_index.exs",
+                 type: :index_not_concurrently
+               },
+               %{
+                 line: 9,
+                 path: "test/example_migrations/20220725111000_create_index.exs",
+                 type: :index_not_concurrently
+               },
+               %{
+                 line: 3,
+                 path: "test/example_migrations/20220725111501_create_unique_index.exs",
+                 type: :index_not_concurrently
+               },
+               %{
+                 line: 4,
+                 path: "test/example_migrations/20220725111501_create_unique_index.exs",
+                 type: :index_not_concurrently
+               },
+               %{
+                 line: 8,
+                 path: "test/example_migrations/20220725111501_create_unique_index.exs",
+                 type: :index_not_concurrently
+               },
+               %{
+                 line: 9,
+                 path: "test/example_migrations/20220725111501_create_unique_index.exs",
+                 type: :index_not_concurrently
                }
              ]
            } == Runner.check_migrations(migrations_paths: file_paths)


### PR DESCRIPTION
It will add support to the `unique_index`, `drop` and `drop_if_exists` checkers if they are set up in the `concurrently: true` options.

Let me know your thoughts about these changes.