### PR TITLE
Concurrently attributes missing checker

### DIFF
--- a/lib/ast_parser_full_detections.ex
+++ b/lib/ast_parser_full_detections.ex
@@ -1,0 +1,78 @@
+defmodule ExcellentMigrations.AstParserFullDetections do
+  @moduledoc false
+
+  @index_functions [:create, :create_if_not_exists, :drop, :drop_if_exists]
+  @index_types [:index, :unique_index]
+
+  def parse(ast) do
+    full_ast_detections(ast)
+  end
+
+  defp full_ast_detections(ast) do
+    [
+      &detect_invalid_index_concurrently/1
+    ]
+    |> Enum.map(&apply(&1, [ast]))
+    |> Enum.concat()
+  end
+
+  defp detect_invalid_index_concurrently(ast) do
+    default = %{
+      line: nil,
+      is_index_concurrently?: false,
+      has_transaction?: false,
+      has_lock?: false
+    }
+
+    ast
+    |> Macro.postwalk(default, &detect_invalid_index_concurrently_inner/2)
+    |> case do
+      {_, %{is_index_concurrently?: false}} ->
+        []
+
+      {_, %{has_lock?: true, has_transaction?: true}} ->
+        []
+
+      {_, %{has_lock?: true, has_transaction?: false, line: line}} ->
+        [{:index_concurrently_without_disable_migration_lock, line}]
+
+      {_, %{has_lock?: false, has_transaction?: true, line: line}} ->
+        [{:index_concurrently_without_disable_ddl_transaction, line}]
+
+      {_, %{line: line}} ->
+        [
+          {:index_concurrently_without_disable_migration_lock, line},
+          {:index_concurrently_without_disable_ddl_transaction, line}
+        ]
+    end
+  end
+
+  defp detect_invalid_index_concurrently_inner(
+         {fun_name, location, [{operation, _, [_, _, options]}]} = ast_part,
+         acc
+       )
+       when fun_name in @index_functions and operation in @index_types do
+    is_concurrently? = Keyword.get(options, :concurrently, false) || acc.is_index_concurrently?
+    line = if is_concurrently?, do: Keyword.get(location, :line), else: acc.line
+
+    {ast_part, %{acc | is_index_concurrently?: is_concurrently?, line: line}}
+  end
+
+  defp detect_invalid_index_concurrently_inner(
+         {:disable_ddl_transaction, _, [true]} = ast_part,
+         acc
+       ) do
+    {ast_part, %{acc | has_transaction?: true}}
+  end
+
+  defp detect_invalid_index_concurrently_inner(
+         {:disable_migration_lock, _, [true]} = ast_part,
+         acc
+       ) do
+    {ast_part, %{acc | has_lock?: true}}
+  end
+
+  defp detect_invalid_index_concurrently_inner(ast_part, acc) do
+    {ast_part, acc}
+  end
+end

--- a/lib/ast_parser_full_detections.ex
+++ b/lib/ast_parser_full_detections.ex
@@ -20,8 +20,8 @@ defmodule ExcellentMigrations.AstParserFullDetections do
     default = %{
       line: nil,
       is_index_concurrently?: false,
-      has_transaction?: false,
-      has_lock?: false
+      ddl_transaction_disabled?: false,
+      lock_disabled?: false
     }
 
     ast
@@ -30,13 +30,13 @@ defmodule ExcellentMigrations.AstParserFullDetections do
       {_, %{is_index_concurrently?: false}} ->
         []
 
-      {_, %{has_lock?: true, has_transaction?: true}} ->
+      {_, %{lock_disabled?: true, ddl_transaction_disabled?: true}} ->
         []
 
-      {_, %{has_lock?: true, has_transaction?: false, line: line}} ->
+      {_, %{lock_disabled?: true, ddl_transaction_disabled?: false, line: line}} ->
         [{:index_concurrently_without_disable_migration_lock, line}]
 
-      {_, %{has_lock?: false, has_transaction?: true, line: line}} ->
+      {_, %{lock_disabled?: false, ddl_transaction_disabled?: true, line: line}} ->
         [{:index_concurrently_without_disable_ddl_transaction, line}]
 
       {_, %{line: line}} ->
@@ -62,14 +62,14 @@ defmodule ExcellentMigrations.AstParserFullDetections do
          {:disable_ddl_transaction, _, [true]} = ast_part,
          acc
        ) do
-    {ast_part, %{acc | has_transaction?: true}}
+    {ast_part, %{acc | ddl_transaction_disabled?: true}}
   end
 
   defp detect_invalid_index_concurrently_inner(
          {:disable_migration_lock, _, [true]} = ast_part,
          acc
        ) do
-    {ast_part, %{acc | has_lock?: true}}
+    {ast_part, %{acc | lock_disabled?: true}}
   end
 
   defp detect_invalid_index_concurrently_inner(ast_part, acc) do

--- a/lib/dangers_detector.ex
+++ b/lib/dangers_detector.ex
@@ -66,10 +66,9 @@ defmodule ExcellentMigrations.DangersDetector do
   def detect_dangers(ast, source_code) do
     parsed_dangers =
       [
-        &AstParser.parse/1,
-        &AstParserFullDetections.parse/1
+        AstParser.parse(ast),
+        AstParserFullDetections.parse(ast)
       ]
-      |> Enum.map(&apply(&1, [ast]))
       |> Enum.concat()
 
     parsed_safety_assured = ConfigCommentsParser.parse(source_code)

--- a/lib/runner.ex
+++ b/lib/runner.ex
@@ -23,6 +23,8 @@ defmodule ExcellentMigrations.Runner do
           | :raw_sql_executed
           | :table_dropped
           | :table_renamed
+          | :index_concurrently_without_disable_ddl_transaction
+          | :index_concurrently_without_disable_migration_lock
 
   @type danger :: %{
           type: danger_type,

--- a/test/example_migrations/20220726000151_create_index_concurrently_valid.exs
+++ b/test/example_migrations/20220726000151_create_index_concurrently_valid.exs
@@ -1,0 +1,18 @@
+defmodule ExcellentMigrations.CreateIndexConcurrently do
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    create(index(:dumplings, [:dough], concurrently: true))
+    create_if_not_exists(index(:dumplings, [:dough], concurrently: true))
+    create(unique_index(:dumplings, [:dough], concurrently: true))
+    create_if_not_exists(unique_index(:dumplings, [:dough], concurrently: true))
+  end
+
+  def down do
+    drop(index(:dumplings, [:dough], concurrently: true))
+    drop_if_exists(index(:dumplings, [:dough], concurrently: true))
+    drop(unique_index(:dumplings, [:dough], concurrently: true))
+    drop_if_exists(unique_index(:dumplings, [:dough], concurrently: true))
+  end
+end

--- a/test/example_migrations/20220726010151_create_index_concurrently_invalid.exs
+++ b/test/example_migrations/20220726010151_create_index_concurrently_invalid.exs
@@ -1,0 +1,15 @@
+defmodule ExcellentMigrations.CreateIndexConcurrentlyInvalid do
+  def up do
+    create(index(:dumplings, [:dough], concurrently: true))
+    create_if_not_exists(index(:dumplings, [:dough], concurrently: true))
+    create(unique_index(:dumplings, [:dough], concurrently: true))
+    create_if_not_exists(unique_index(:dumplings, [:dough], concurrently: true))
+  end
+
+  def down do
+    drop(index(:dumplings, [:dough], concurrently: true))
+    drop_if_exists(index(:dumplings, [:dough], concurrently: true))
+    drop(unique_index(:dumplings, [:dough], concurrently: true))
+    drop_if_exists(unique_index(:dumplings, [:dough], concurrently: true))
+  end
+end

--- a/test/example_migrations/20220804010152_create_index_concurrently_without_disable_ddl_transaction.exs
+++ b/test/example_migrations/20220804010152_create_index_concurrently_without_disable_ddl_transaction.exs
@@ -1,0 +1,17 @@
+defmodule ExcellentMigrations.CreateIndexConcurrentlyWithoutDisableDDLTransaction do
+  @disable_migration_lock true
+
+  def up do
+    create(index(:dumplings, [:dough], concurrently: true))
+    create_if_not_exists(index(:dumplings, [:dough], concurrently: true))
+    create(unique_index(:dumplings, [:dough], concurrently: true))
+    create_if_not_exists(unique_index(:dumplings, [:dough], concurrently: true))
+  end
+
+  def down do
+    drop(index(:dumplings, [:dough], concurrently: true))
+    drop_if_exists(index(:dumplings, [:dough], concurrently: true))
+    drop(unique_index(:dumplings, [:dough], concurrently: true))
+    drop_if_exists(unique_index(:dumplings, [:dough], concurrently: true))
+  end
+end

--- a/test/example_migrations/20220804010153_create_index_concurrently_without_disable_migration_lock.exs
+++ b/test/example_migrations/20220804010153_create_index_concurrently_without_disable_migration_lock.exs
@@ -1,0 +1,17 @@
+defmodule ExcellentMigrations.CreateIndexConcurrentlyWithoutDisableMigrationLock do
+  @disable_ddl_transaction true
+
+  def up do
+    create(index(:dumplings, [:dough], concurrently: true))
+    create_if_not_exists(index(:dumplings, [:dough], concurrently: true))
+    create(unique_index(:dumplings, [:dough], concurrently: true))
+    create_if_not_exists(unique_index(:dumplings, [:dough], concurrently: true))
+  end
+
+  def down do
+    drop(index(:dumplings, [:dough], concurrently: true))
+    drop_if_exists(index(:dumplings, [:dough], concurrently: true))
+    drop(unique_index(:dumplings, [:dough], concurrently: true))
+    drop_if_exists(unique_index(:dumplings, [:dough], concurrently: true))
+  end
+end

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -4,7 +4,7 @@ defmodule ExcellentMigrations.RunnerTest do
 
   test "it should be valid migration files" do
     file_paths = [
-      "test/example_migrations/20220726000151_create_index_concurrently_valid.exs"
+      # "test/example_migrations/20220726000151_create_index_concurrently_valid.exs"
     ]
 
     assert :safe == Runner.check_migrations(migrations_paths: file_paths)
@@ -22,7 +22,9 @@ defmodule ExcellentMigrations.RunnerTest do
       "test/example_migrations/20191026103008_change_column_type.exs",
       "test/example_migrations/20220725111000_create_index.exs",
       "test/example_migrations/20220725111501_create_unique_index.exs",
-      "test/example_migrations/20220726010151_create_index_concurrently_invalid.exs"
+      "test/example_migrations/20220726010151_create_index_concurrently_invalid.exs",
+      "test/example_migrations/20220804010152_create_index_concurrently_without_disable_ddl_transaction.exs",
+      "test/example_migrations/20220804010153_create_index_concurrently_without_disable_migration_lock.exs"
     ]
 
     assert {
@@ -109,17 +111,29 @@ defmodule ExcellentMigrations.RunnerTest do
                  type: :index_not_concurrently
                },
                %{
-                line: 13,
-                path:
-                  "test/example_migrations/20220726010151_create_index_concurrently_invalid.exs",
-                type: :index_concurrently_without_disable_migration_lock
-              },
-              %{
-                line: 13,
-                path:
-                  "test/example_migrations/20220726010151_create_index_concurrently_invalid.exs",
-                type: :index_concurrently_without_disable_ddl_transaction
-              }
+                 line: 13,
+                 path:
+                   "test/example_migrations/20220726010151_create_index_concurrently_invalid.exs",
+                 type: :index_concurrently_without_disable_migration_lock
+               },
+               %{
+                 line: 13,
+                 path:
+                   "test/example_migrations/20220726010151_create_index_concurrently_invalid.exs",
+                 type: :index_concurrently_without_disable_ddl_transaction
+               },
+               %{
+                 line: 15,
+                 path:
+                   "test/example_migrations/20220804010152_create_index_concurrently_without_disable_ddl_transaction.exs",
+                 type: :index_concurrently_without_disable_migration_lock
+               },
+               %{
+                 line: 15,
+                 path:
+                   "test/example_migrations/20220804010153_create_index_concurrently_without_disable_migration_lock.exs",
+                 type: :index_concurrently_without_disable_ddl_transaction
+               }
              ]
            } == Runner.check_migrations(migrations_paths: file_paths)
   end

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -4,7 +4,7 @@ defmodule ExcellentMigrations.RunnerTest do
 
   test "it should be valid migration files" do
     file_paths = [
-      # "test/example_migrations/20220726000151_create_index_concurrently_valid.exs"
+      "test/example_migrations/20220726000151_create_index_concurrently_valid.exs"
     ]
 
     assert :safe == Runner.check_migrations(migrations_paths: file_paths)

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -2,6 +2,14 @@ defmodule ExcellentMigrations.RunnerTest do
   use ExUnit.Case
   alias ExcellentMigrations.Runner
 
+  test "it should be valid migration files" do
+    file_paths = [
+      "test/example_migrations/20220726000151_create_index_concurrently_valid.exs"
+    ]
+
+    assert :safe == Runner.check_migrations(migrations_paths: file_paths)
+  end
+
   test "generates warning messages for migration files" do
     file_paths = [
       "test/example_migrations/20191026103001_create_table_and_index.exs",
@@ -11,7 +19,8 @@ defmodule ExcellentMigrations.RunnerTest do
       "test/example_migrations/20191026103005_remove_column.exs",
       "test/example_migrations/20191026103006_rename_table.exs",
       "test/example_migrations/20191026103007_add_column_with_default_value.exs",
-      "test/example_migrations/20191026103008_change_column_type.exs"
+      "test/example_migrations/20191026103008_change_column_type.exs",
+      "test/example_migrations/20220726010151_create_index_concurrently_invalid.exs"
     ]
 
     assert {
@@ -56,6 +65,18 @@ defmodule ExcellentMigrations.RunnerTest do
                  line: 4,
                  path: "test/example_migrations/20191026103008_change_column_type.exs",
                  type: :column_type_changed
+               },
+               %{
+                 line: 13,
+                 path:
+                   "test/example_migrations/20220726010151_create_index_concurrently_invalid.exs",
+                 type: :index_concurrently_without_disable_migration_lock
+               },
+               %{
+                 line: 13,
+                 path:
+                   "test/example_migrations/20220726010151_create_index_concurrently_invalid.exs",
+                 type: :index_concurrently_without_disable_ddl_transaction
                }
              ]
            } == Runner.check_migrations(migrations_paths: file_paths)


### PR DESCRIPTION
#8 

It will add a checker to verify if the following module attributes are set up to true when the migration contains an operation to add or drop an index concurrently.

```Elixir
@disable_ddl_transaction true
@disable_migration_lock true
```

As said [here](https://github.com/Artur-Sulej/excellent_migrations/issues/8#issuecomment-1195897316), the unique way that I found to include this feature was going through the entire code_ast.

* Created a new module to add full detections checkers (`AstParserFullDetections`)
* Add the `detect_invalid_index_concurrently` validation

The checker consists of post-walk with the AST and checking:
* If some of the operations are adding a concurrent index 
```Elixir
defp detect_invalid_index_concurrently_inner({fun_name, location, [{operation, _, [_, _, options]}]} = ast_part, acc)
     when fun_name in @index_functions and operation in @index_types do

  is_concurrently? = Keyword.get(options, :concurrently, false) || acc.is_index_concurrently?
  line = if is_concurrently?, do: Keyword.get(location, :line), else: acc.line

  {ast_part, %{acc | is_index_concurrently?: is_concurrently?, line: line}}
end
```
* If the attributes exist in the module and setted as `true`
```Elixir
defp detect_invalid_index_concurrently_inner( {:disable_ddl_transaction, _, [true]} = ast_part, acc) do
  {ast_part, %{acc | has_transaction?: true}}
end

defp detect_invalid_index_concurrently_inner(disable_migration_lock, _, [true]} = ast_part, acc) do
  {ast_part, %{acc | has_lock?: true}}
end
```

I also created this initial accumulator map with these default params to be easier to handle with this logic:
```Elixir
%{
      line: nil,
      is_index_concurrently?: false,
      has_transaction?: false,
      has_lock?: false
}
```

For now, I have named these news danger types `index_concurrently_without_disable_ddl_transaction` and `index_concurrently_without_disable_migration_lock,` but I'm not sure which will be a more appropriate name for them. 


Let me know your thoughts on that.