### PR TITLE
Fixed detect_many_columns_index parsing

### DIFF
--- a/lib/ast_parser.ex
+++ b/lib/ast_parser.ex
@@ -52,7 +52,7 @@ defmodule ExcellentMigrations.AstParser do
   defp detect_index_not_concurrently(_), do: []
 
   defp detect_many_columns_index({fun_name, location, [{:index, _, [_, columns, options]}]})
-       when fun_name in [:create, :create_if_not_exists] do
+       when fun_name in [:create, :create_if_not_exists] and is_list(columns) do
     cond do
       Keyword.get(options, :unique) ->
         []

--- a/test/ast_parser_test.exs
+++ b/test/ast_parser_test.exs
@@ -213,12 +213,16 @@ defmodule ExcellentMigrations.AstParserTest do
 
     ast_ok = string_to_ast("create index(\"ingredients\", [:a, :b, :c], concurrently: true)")
 
+    ast_single_with_opts =
+      string_to_ast("create index(\"ingredients\", :one_column, concurrently: true)")
+
     assert [index_not_concurrently: 1, many_columns_index: 1] ==
              AstParser.parse(ast_too_many_not_concurrently)
 
     assert [many_columns_index: 1] == AstParser.parse(ast_many_columns)
     assert [] == AstParser.parse(ast_many_but_unique)
     assert [] == AstParser.parse(ast_ok)
+    assert [] == AstParser.parse(ast_single_with_opts)
   end
 
   test "detects column added with default" do


### PR DESCRIPTION
Hello!

I found a bug on `detect_many_columns_index` where it would raise an error and crash.
This happens when creating a single column index if it also had options.

Eg:

```elixir
create index(:a_table, :my_column, where: "arbitrary_option = null")
```

```
** (Protocol.UndefinedError) protocol Enumerable not implemented for :my_column of type Atom. This protocol is implemented for the following type(s): Date.Range, File.Stream, Function, GenEvent.Stream, HashDict, HashSet, IO.Stream, Jason.OrderedObject, List, Map, MapSet, Range, Stream
     stacktrace:
     (elixir 1.13.2) lib/enum.ex:1: Enumerable.impl_for!/1
     (elixir 1.13.2) lib/enum.ex:155: Enumerable.count/1
     (elixir 1.13.2) lib/enum.ex:656: Enum.count/1
     (excellent_migrations 0.1.5) lib/ast_parser.ex:60: ExcellentMigrations.AstParser.detect_many_columns_index/1
     (excellent_migrations 0.1.5) lib/ast_parser.ex:24: ExcellentMigrations.AstParser.detect_dangers/1
     (excellent_migrations 0.1.5) lib/ast_parser.ex:15: anonymous fn/3 in ExcellentMigrations.AstParser.traverse_ast/2
     (excellent_migrations 0.1.5) lib/ast_parser.ex:14: ExcellentMigrations.AstParser.traverse_ast/2
```

This PR fixes the issue and adds a unit test for good measure.

lmk if something else is needed! :)