### PR TITLE
detect when adding a reference that lock writes

### DIFF
--- a/test/ast_parser_test.exs
+++ b/test/ast_parser_test.exs
@@ -101,7 +101,11 @@ defmodule ExcellentMigrations.AstParserTest do
   end
 
   test "detects danger and safety assured" do
-    assert [safety_assured: [:index_not_concurrently], index_not_concurrently: 7] ==
+    assert [
+             safety_assured: [:index_not_concurrently, :blocking_reference_added],
+             blocking_reference_added: 4,
+             index_not_concurrently: 7
+           ] ==
              AstParser.parse(safety_assured_ast())
   end
 
@@ -332,7 +336,7 @@ defmodule ExcellentMigrations.AstParserTest do
 
   defp safety_assured_ast do
     string_to_ast("""
-    @safety_assured [:index_not_concurrently]
+    @safety_assured [:index_not_concurrently, :blocking_reference_added]
     def change do
       alter(table(:recipes)) do
         add(:cookbook_id, references(:cookbooks, on_delete: :delete_all), null: false)

--- a/test/ast_parser_test.exs
+++ b/test/ast_parser_test.exs
@@ -102,8 +102,8 @@ defmodule ExcellentMigrations.AstParserTest do
 
   test "detects danger and safety assured" do
     assert [
-             safety_assured: [:index_not_concurrently, :blocking_reference_added],
-             blocking_reference_added: 4,
+             safety_assured: [:index_not_concurrently],
+             column_reference_added: 4,
              index_not_concurrently: 7
            ] ==
              AstParser.parse(safety_assured_ast())
@@ -336,7 +336,7 @@ defmodule ExcellentMigrations.AstParserTest do
 
   defp safety_assured_ast do
     string_to_ast("""
-    @safety_assured [:index_not_concurrently, :blocking_reference_added]
+    @safety_assured [:index_not_concurrently]
     def change do
       alter(table(:recipes)) do
         add(:cookbook_id, references(:cookbooks, on_delete: :delete_all), null: false)

--- a/test/example_migrations/20221116230257_add_foreign_key_invalid.exs
+++ b/test/example_migrations/20221116230257_add_foreign_key_invalid.exs
@@ -1,0 +1,9 @@
+defmodule DB.Repo.Migrations.AddForeignKeyInvalid do
+  use Ecto.Migration
+
+  def change do
+    alter table("posts") do
+      add(:group_id, references("groups"))
+    end
+  end
+end

--- a/test/example_migrations/20221116234819_add_non_blocking_foreign_key.exs
+++ b/test/example_migrations/20221116234819_add_non_blocking_foreign_key.exs
@@ -1,0 +1,9 @@
+defmodule DB.Repo.Migrations.AddNonBlockingForeignKey do
+  use Ecto.Migration
+
+  def change do
+    alter table("posts") do
+      add(:group_id, references("groups", validate: false))
+    end
+  end
+end

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -4,7 +4,8 @@ defmodule ExcellentMigrations.RunnerTest do
 
   test "it should be valid migration files" do
     file_paths = [
-      "test/example_migrations/20220726000151_create_index_concurrently_valid.exs"
+      "test/example_migrations/20220726000151_create_index_concurrently_valid.exs",
+      "test/example_migrations/20221116234819_add_non_blocking_foreign_key.exs"
     ]
 
     assert :safe == Runner.check_migrations(migrations_paths: file_paths)
@@ -24,12 +25,18 @@ defmodule ExcellentMigrations.RunnerTest do
       "test/example_migrations/20220725111501_create_unique_index.exs",
       "test/example_migrations/20220726010151_create_index_concurrently_invalid.exs",
       "test/example_migrations/20220804010152_create_index_concurrently_without_disable_ddl_transaction.exs",
-      "test/example_migrations/20220804010153_create_index_concurrently_without_disable_migration_lock.exs"
+      "test/example_migrations/20220804010153_create_index_concurrently_without_disable_migration_lock.exs",
+      "test/example_migrations/20221116230257_add_foreign_key_invalid.exs"
     ]
 
     assert {
              :dangerous,
              [
+               %{
+                 line: 4,
+                 path: "test/example_migrations/20191026103001_create_table_and_index.exs",
+                 type: :blocking_reference_added
+               },
                %{
                  line: 8,
                  path: "test/example_migrations/20191026103001_create_table_and_index.exs",
@@ -132,7 +139,12 @@ defmodule ExcellentMigrations.RunnerTest do
                  line: 15,
                  path:
                    "test/example_migrations/20220804010153_create_index_concurrently_without_disable_migration_lock.exs",
-                 type: :index_concurrently_without_disable_migration_lock
+                 type: :index_concurrently_without_disable_ddl_transaction
+               },
+               %{
+                 line: 6,
+                 path: "test/example_migrations/20221116230257_add_foreign_key_invalid.exs",
+                 type: :blocking_reference_added
                }
              ]
            } == Runner.check_migrations(migrations_paths: file_paths)

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -32,11 +32,12 @@ defmodule ExcellentMigrations.RunnerTest do
     assert {
              :dangerous,
              [
-               %{
+              %{
                  line: 4,
                  path: "test/example_migrations/20191026103001_create_table_and_index.exs",
-                 type: :blocking_reference_added
+                 type: :column_reference_added
                },
+
                %{
                  line: 8,
                  path: "test/example_migrations/20191026103001_create_table_and_index.exs",
@@ -139,12 +140,12 @@ defmodule ExcellentMigrations.RunnerTest do
                  line: 15,
                  path:
                    "test/example_migrations/20220804010153_create_index_concurrently_without_disable_migration_lock.exs",
-                 type: :index_concurrently_without_disable_ddl_transaction
+                 type: :index_concurrently_without_disable_migration_lock
                },
                %{
                  line: 6,
                  path: "test/example_migrations/20221116230257_add_foreign_key_invalid.exs",
-                 type: :blocking_reference_added
+                 type: :column_reference_added
                }
              ]
            } == Runner.check_migrations(migrations_paths: file_paths)


### PR DESCRIPTION
### What I'm doing

Adding a new check to avoid locks when an Ecto Migration includes a foreign key.

### Why?

As the README suggests, adding a migration like this:

```elixir
def change do
  alter table("posts") do
    add :group_id, references("groups")
  end
end
```

It would block writes on both tables. This PR includes a new check to detect these cases and report them as dangerous.

### Approach

Add a new function in the AST Parser to detect when a column is added and includes `references` to another table; then, we check if the `validate: false` option is given.

### How to review this PR / I’d like feedback on

This is my first PR here, so any constructive feedback is welcome.