### PR TITLE
Detecting column with volatile default

### DIFF
--- a/lib/dangers_detector.ex
+++ b/lib/dangers_detector.ex
@@ -14,11 +14,17 @@ defmodule ExcellentMigrations.DangersDetector do
   @type ast :: list | tuple | atom | String.t()
 
   @type danger_type ::
-          :column_added_with_default
+          :check_constraint_added
+          | :column_added_with_default
+          | :column_reference_added
           | :column_removed
           | :column_renamed
           | :column_type_changed
+          | :column_volatile_default
+          | :index_concurrently_without_disable_ddl_transaction
+          | :index_concurrently_without_disable_migration_lock
           | :index_not_concurrently
+          | :json_column_added
           | :many_columns_index
           | :not_null_added
           | :operation_delete
@@ -27,8 +33,6 @@ defmodule ExcellentMigrations.DangersDetector do
           | :raw_sql_executed
           | :table_dropped
           | :table_renamed
-          | :index_concurrently_without_disable_ddl_transaction
-          | :index_concurrently_without_disable_migration_lock
 
   @type line :: integer
 

--- a/lib/runner.ex
+++ b/lib/runner.ex
@@ -10,11 +10,17 @@ defmodule ExcellentMigrations.Runner do
   }
 
   @type danger_type ::
-          :column_added_with_default
+          :check_constraint_added
+          | :column_added_with_default
+          | :column_reference_added
           | :column_removed
           | :column_renamed
           | :column_type_changed
+          | :column_volatile_default
+          | :index_concurrently_without_disable_ddl_transaction
+          | :index_concurrently_without_disable_migration_lock
           | :index_not_concurrently
+          | :json_column_added
           | :many_columns_index
           | :not_null_added
           | :operation_delete
@@ -23,8 +29,6 @@ defmodule ExcellentMigrations.Runner do
           | :raw_sql_executed
           | :table_dropped
           | :table_renamed
-          | :index_concurrently_without_disable_ddl_transaction
-          | :index_concurrently_without_disable_migration_lock
 
   @type danger :: %{
           type: danger_type,


### PR DESCRIPTION
This PR adds a new check `column_volatile_default`, which detects adding a volatile default to an existing column or adding a new column with a volatile default. 

It's also important to differentiate this check from `column_added_with_default`, because this one is safe from certain db versions and users may want to skip this check with:

```elixir
config :excellent_migrations, skip_checks: [:column_added_with_default]
```

---

From [PostgreSQL docs](https://www.postgresql.org/docs/current/ddl-alter.html#DDL-ALTER-ADDING-A-COLUMN):
> From PostgreSQL 11, adding a column with a constant default value no longer means that each row of the table needs to be updated when the ALTER TABLE statement is executed. Instead, the default value will be returned the next time the row is accessed, and applied when the table is rewritten, making the ALTER TABLE very fast even on large tables.

> However, if the default value is volatile (e.g., clock_timestamp()) each row will need to be updated with the value calculated at the time ALTER TABLE is executed. To avoid a potentially lengthy update operation, particularly if you intend to fill the column with mostly nondefault values anyway, it may be preferable to add the column with no default, insert the correct values using UPDATE, and then add any desired default as described below.



