### PR TITLE
Replace System.stop/1 with Mix.raise/1

### DIFF
--- a/lib/mix/tasks/check_safety.ex
+++ b/lib/mix/tasks/check_safety.ex
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.ExcellentMigrations.CheckSafety do
           |> Logger.warn()
         end)
 
-        System.stop(1)
+        Mix.raise("Dangerous operations detected in migrations!")
     end
   end
 end

--- a/lib/mix/tasks/migrate.ex
+++ b/lib/mix/tasks/migrate.ex
@@ -16,7 +16,7 @@ defmodule Mix.Tasks.ExcellentMigrations.Migrate do
           |> Logger.error()
         end)
 
-        System.stop(1)
+        Mix.raise("Dangerous operations detected in migrations!")
     end
   end
 end


### PR DESCRIPTION
[closes #22]

This should ensure a non-zero exit status is returned when dangers are detected.

Example:
```fish
» mix excellent_migrations.check_safety; echo $status

09:20:19.518 [warning] Index not concurrently in priv/repo/migrations/20230103220859_testing-stuff.exs:5
==> app
** (Mix) Dangerous operations detected in migrations!
1
```
and
```fish
» mix excellent_migrations.check_safety; echo $status

09:22:41.930 [info] No dangerous operations detected in migrations.
0
```