### PR TITLE
Fix transposed index errors

### DIFF
--- a/lib/ast_parser_full_detections.ex
+++ b/lib/ast_parser_full_detections.ex
@@ -34,10 +34,10 @@ defmodule ExcellentMigrations.AstParserFullDetections do
         []
 
       {_, %{lock_disabled?: true, ddl_transaction_disabled?: false, line: line}} ->
-        [{:index_concurrently_without_disable_migration_lock, line}]
+        [{:index_concurrently_without_disable_ddl_transaction, line}]
 
       {_, %{lock_disabled?: false, ddl_transaction_disabled?: true, line: line}} ->
-        [{:index_concurrently_without_disable_ddl_transaction, line}]
+        [{:index_concurrently_without_disable_migration_lock, line}]
 
       {_, %{line: line}} ->
         [

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -126,13 +126,13 @@ defmodule ExcellentMigrations.RunnerTest do
                  line: 15,
                  path:
                    "test/example_migrations/20220804010152_create_index_concurrently_without_disable_ddl_transaction.exs",
-                 type: :index_concurrently_without_disable_migration_lock
+                 type: :index_concurrently_without_disable_ddl_transaction
                },
                %{
                  line: 15,
                  path:
                    "test/example_migrations/20220804010153_create_index_concurrently_without_disable_migration_lock.exs",
-                 type: :index_concurrently_without_disable_ddl_transaction
+                 type: :index_concurrently_without_disable_migration_lock
                }
              ]
            } == Runner.check_migrations(migrations_paths: file_paths)


### PR DESCRIPTION
I believe these errors are incorrectly transposed, e.g. if `ddl_transaction_disabled?=false`, then the error should be `:index_concurrently_without_disable_ddl_transaction` not `:index_concurrently_without_disable_migration_lock`.