### PR TITLE
Provide guidance links in mix tasks' `Logger.error` output

### DIFF
--- a/lib/message_generator.ex
+++ b/lib/message_generator.ex
@@ -2,7 +2,13 @@ defmodule ExcellentMigrations.MessageGenerator do
   @moduledoc false
 
   def build_message(%{type: type, path: path, line: line}) do
-    "#{build_message(type)} in #{path}:#{line}"
+    """
+    #{build_message(type)} in #{path}:#{line}
+
+        For more info:
+          * https://github.com/Artur-Sulej/excellent_migrations#checks
+          * https://github.com/Artur-Sulej/excellent_migrations#assuring-safety
+    """
   end
 
   def build_message(type) do


### PR DESCRIPTION
We just added `excellent_migrations` to a large repository with many newish Elixir developers contributing to it. I noticed that the current `Logger.error` output can be somewhat cryptic, and it isn't clear what the next steps are or where the errors originate.

This pull request adds links to the README's 'Checks' and 'Assuring Safety' section to the error output of the mix tasks.

I haven't yet determined how to do the same for the credo check, but I'll happily add it if this first PR is welcomed.

## Before
![Screen Shot 2023-03-08 at 2 58 27 PM](https://user-images.githubusercontent.com/4386645/223865955-bd68883f-b18d-4725-bdf3-3322fb66e52a.png)

## After

![Screen Shot 2023-03-08 at 3 20 26 PM](https://user-images.githubusercontent.com/4386645/223866123-2e774cea-6ade-4d3a-8dd5-cf7c32a30ee2.png)

