### PR TITLE
Correct failure exit code

### DIFF
--- a/lib/mix/tasks/check_safety.ex
+++ b/lib/mix/tasks/check_safety.ex
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.ExcellentMigrations.CheckSafety do
           |> Logger.warn()
         end)
 
-        System.stop(1)
+        exit({:shutdown, 1})
     end
   end
 end

--- a/lib/mix/tasks/migrate.ex
+++ b/lib/mix/tasks/migrate.ex
@@ -16,7 +16,7 @@ defmodule Mix.Tasks.ExcellentMigrations.Migrate do
           |> Logger.error()
         end)
 
-        System.stop(1)
+        exit({:shutdown, 1})
     end
   end
 end


### PR DESCRIPTION
`System.stop/1` seems to have its status code swallowed by Mix for some reason. I'm not entirely sure why but when checking other implementations such as credo, they are using the `exit/1` kernel function instead.

After testing, this properly produces an exit code of `1` for failure cases where previously they were `0`, despite the call `System.stop(1)`.

This allows the cli commands to properly halt CI processes and makes building wrapper scripts easier.

## Test example

```
# Call with `mix text_exit && echo $?` to see true exit code
defmodule Mix.Tasks.TestExit do
  use Mix.Task
  require Logger

  def run(args) do
    Logger.info("Trying to exit with status code 1")
    System.stop(1)
  end
end
```

## Corrected example

```
# Call with `mix text_exit_corrected && echo $?` to see true exit code
defmodule Mix.Tasks.TestExitCorrected do
  use Mix.Task
  require Logger

  def run(args) do
    Logger.info("Trying to exit with status code 1")
    exit({:shutdown, 1})
  end
end
```