### PR TITLE
GitHub workflow fix

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -10,7 +10,7 @@ jobs:
   build:
 
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Fix for [the error](https://github.com/Artur-Sulej/excellent_migrations/actions/runs/4764490040/jobs/8780438403?pr=28):
> Error: Tried to map a target OS from env. variable 'ImageOS' (got ubuntu22), but failed. If you're using a self-hosted runner, you should set 'env': 'ImageOS': ... to one of the following: ['ubuntu16', 'ubuntu18', 'ubuntu20', 'win16', 'win19']