### PR TITLE
Use Logger.warning/2

### DIFF
--- a/lib/dangers_filter.ex
+++ b/lib/dangers_filter.ex
@@ -18,7 +18,7 @@ defmodule ExcellentMigrations.DangersFilter do
       |> Enum.uniq()
 
     unless Enum.empty?(safety_assured_types) do
-      Logger.warn(
+      Logger.warning(
         "Using module attribute @safety_assured is deprecated. Use config comments instead."
       )
     end

--- a/lib/mix/tasks/check_safety.ex
+++ b/lib/mix/tasks/check_safety.ex
@@ -21,7 +21,7 @@ defmodule Mix.Tasks.ExcellentMigrations.CheckSafety do
         Enum.each(dangers, fn danger ->
           danger
           |> ExcellentMigrations.MessageGenerator.build_message()
-          |> Logger.warn()
+          |> Logger.warning()
         end)
 
         exit({:shutdown, 1})


### PR DESCRIPTION
Remove the `Logger.warn/2` in favor of `Logger.warning/2`

Reference: https://hexdocs.pm/logger/main/Logger.html#warn/2

