### PR TITLE
Detect non-concurrent indices in pipelines

### DIFF
--- a/lib/ast_parser.ex
+++ b/lib/ast_parser.ex
@@ -2,7 +2,6 @@ defmodule ExcellentMigrations.AstParser do
   @moduledoc false
   @max_columns_for_index 3
 
-  @index_functions [:create, :create_if_not_exists, :drop, :drop_if_exists]
   @index_types [:index, :unique_index]
 
   def parse(ast) do
@@ -37,16 +36,14 @@ defmodule ExcellentMigrations.AstParser do
       detect_json_column_added(code_part)
   end
 
-  defp detect_index_not_concurrently({fun_name, location, [{operation, _, [_, _]}]})
-       when fun_name in @index_functions and operation in @index_types do
-    [{:index_not_concurrently, Keyword.get(location, :line)}]
-  end
+  defp detect_index_not_concurrently({operation, location, args})
+       when operation in @index_types do
+    options = List.last(args, [])
 
-  defp detect_index_not_concurrently({fun_name, location, [{operation, _, [_, _, options]}]})
-       when fun_name in @index_functions and operation in @index_types do
-    case Keyword.get(options, :concurrently) do
-      true -> []
-      _ -> [{:index_not_concurrently, Keyword.get(location, :line)}]
+    if is_list(options) and Keyword.get(options, :concurrently) do
+      []
+    else
+      [{:index_not_concurrently, Keyword.get(location, :line)}]
     end
   end
 

--- a/test/example_migrations/20230922211058_create_index_unconventional_structure.exs
+++ b/test/example_migrations/20230922211058_create_index_unconventional_structure.exs
@@ -1,0 +1,8 @@
+defmodule ExcellentMigrations.CreateIndexUnconventionalStructure do
+  def change do
+    dumplings_index = index(:dumplings, [:dough])
+    create(dumplings_index)
+
+    :dumplings |> index([:dough]) |> create()
+  end
+end

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -138,6 +138,26 @@ defmodule ExcellentMigrations.RunnerTest do
            } == Runner.check_migrations(migrations_paths: file_paths)
   end
 
+  test "finds non-concurrent indices in unconventional structures" do
+    file_path = "test/example_migrations/20230922211058_create_index_unconventional_structure.exs"
+
+    assert {
+             :dangerous,
+             [
+               %{
+                 line: 3,
+                 path: file_path,
+                 type: :index_not_concurrently
+               },
+               %{
+                 line: 6,
+                 path: file_path,
+                 type: :index_not_concurrently
+               }
+             ]
+           } == Runner.check_migrations(migrations_paths: [file_path])
+  end
+
   test "no dangerous operations" do
     file_paths = [
       "test/example_migrations/20191026103003_create_table.exs",


### PR DESCRIPTION
Updated the AST parser to not care about surrounding structure instead matching all calls of `index/3` and `unique_index/3`.


- Fixes: https://github.com/Artur-Sulej/excellent_migrations/issues/33

