### PR TITLE
Clarify the postgres instructions for setting NOT NULL on an existing column to prevent an ACCESS EXCLUSIVE lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,9 +555,7 @@ If you're using Postgres 12+, you can add the NOT NULL to the column after valid
 def change do
   execute "ALTER TABLE recipes VALIDATE CONSTRAINT favourite_not_null", ""
 
-  alter table("recipes") do
-    modify :favourite, :boolean, null: false
-  end
+  execute "ALTER TABLE recipes ALTER COLUMN favourite SET NOT NULL", "ALTER TABLE recipes ALTER COLUMN favourite DROP NOT NULL"
 
   drop constraint("recipes", :favourite_not_null)
 end


### PR DESCRIPTION
```elixir
modify :favourite, :boolean, null: false
```
turns into the following SQL:

```SQL
ALTER TABLE recipes
ALTER COLUMN favourite TYPE BOOLEAN
ALTER COLUMN favourite SET NOT NULL
```

It changes both the type and the nullability of the column. Unfortunately, in postgres, even if the type isn't changing (e.g. it was already a boolean), Postgres initiates a full table scan to ensure that everything is okay. This results in taking out an ACCESS EXCLUSIVE lock on the table for the duration. Unfortunately, to avoid this, we need to do another `execute` statement to ensure that just the
```SQL
ALTER COLUMN favourite SET NOT NULL
```
is being run without the
```SQL
ALTER COLUMN favourite TYPE BOOLEAN
```