### PR TITLE
add_check_column_generated_stored

### DIFF
--- a/lib/dangers_detector.ex
+++ b/lib/dangers_detector.ex
@@ -21,6 +21,7 @@ defmodule ExcellentMigrations.DangersDetector do
           | :column_renamed
           | :column_type_changed
           | :column_volatile_default
+          | :column_added_generated_stored
           | :index_concurrently_without_disable_ddl_transaction
           | :index_concurrently_without_disable_migration_lock
           | :index_not_concurrently

--- a/lib/runner.ex
+++ b/lib/runner.ex
@@ -17,6 +17,7 @@ defmodule ExcellentMigrations.Runner do
           | :column_renamed
           | :column_type_changed
           | :column_volatile_default
+          | :column_added_generated_stored
           | :index_concurrently_without_disable_ddl_transaction
           | :index_concurrently_without_disable_migration_lock
           | :index_not_concurrently

--- a/test/ast_parser_test.exs
+++ b/test/ast_parser_test.exs
@@ -335,6 +335,17 @@ defmodule ExcellentMigrations.AstParserTest do
     assert [column_added_with_default: 2] == AstParser.parse(ast)
   end
 
+  test "detects added generated column stored" do
+    ast =
+      string_to_ast("""
+      alter table("recipes") do
+        add :generated_psql, :string, generated: "ALWAYS AS (id::text) STORED"
+      end
+      """)
+
+    assert [column_added_generated_stored: 2] == AstParser.parse(ast)
+  end
+
   test "detects column removed" do
     ast1 = string_to_ast("remove(:size, :string)")
     assert [column_removed: 1] == AstParser.parse(ast1)


### PR DESCRIPTION
I hit this today:
[ecto allows to add](https://hexdocs.pm/ecto_sql/Ecto.Migration.html#add/3) a [generated column](https://www.postgresql.org/docs/current/ddl-generated-columns.html).

```elixir
alter table("posts") do
  add :identity, :integer, generated: "BY DEFAULT AS IDENTITY" # Postgres generated identity column
  add :generated_psql, :string, generated: "ALWAYS AS (id::text) STORED" # Postgres calculated column
  add :generated_other, :string, generated: "CAST(id AS char)" # MySQL and TDS calculated column
end
```

There are 2 types of generated columns but postgres only supports stored which calculates all the values during migration and locks the table. This is not safe on an existing table.