### PR TITLE
make adding check constraint valid with `validate: false`

### DIFF
--- a/lib/ast_parser.ex
+++ b/lib/ast_parser.ex
@@ -174,8 +174,12 @@ defmodule ExcellentMigrations.AstParser do
 
   defp detect_json_column_added(_), do: []
 
-  defp detect_check_constraint({:create, location, [{:constraint, _, _}]}) do
-    [{:check_constraint_added, Keyword.get(location, :line)}]
+  defp detect_check_constraint({:create, location, [{:constraint, _, [_table, _name, options]}]}) do
+    if Keyword.get(options, :validate) == false do
+      []
+    else
+      [{:check_constraint_added, Keyword.get(location, :line)}]
+    end
   end
 
   defp detect_check_constraint(_), do: []

--- a/test/ast_parser_test.exs
+++ b/test/ast_parser_test.exs
@@ -92,6 +92,24 @@ defmodule ExcellentMigrations.AstParserTest do
     assert [check_constraint_added: 1] == AstParser.parse(ast)
   end
 
+  test "does not detect check constraint added with validate: false" do
+    ast =
+      string_to_ast(~s"""
+      create constraint("ingredients", :price_must_be_positive, check: "price > 0", validate: false)
+      """)
+
+    assert [] == AstParser.parse(ast)
+  end
+
+  test "detects check constraint added with validate: true" do
+    ast =
+      string_to_ast(~s"""
+      create constraint("ingredients", :price_must_be_positive, check: "price > 0", validate: true)
+      """)
+
+    assert [check_constraint_added: 1] == AstParser.parse(ast)
+  end
+
   test "detects records modified" do
     ast1 =
       string_to_ast("""


### PR DESCRIPTION
As stated in the README, creating a constraint with `validate: false` is safe. Make sure this case doesn't raise an issue.
