### PR TITLE
Add query operations to operation types list for assuring safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,6 +795,8 @@ Possible operation types are:
 * `operation_delete`
 * `operation_insert`
 * `operation_update`
+* `operation_query`
+* `operation_one`
 * `raw_sql_executed`
 * `table_dropped`
 * `table_renamed`

--- a/README.md
+++ b/README.md
@@ -795,8 +795,6 @@ Possible operation types are:
 * `operation_delete`
 * `operation_insert`
 * `operation_update`
-* `operation_query`
-* `operation_one`
 * `raw_sql_executed`
 * `table_dropped`
 * `table_renamed`

--- a/lib/ast_parser.ex
+++ b/lib/ast_parser.ex
@@ -5,6 +5,12 @@ defmodule ExcellentMigrations.AstParser do
   @index_functions [:create, :create_if_not_exists, :drop, :drop_if_exists]
   @index_types [:index, :unique_index]
 
+  @repo_insert_operations [:insert, :insert!, :insert_all, :insert_or_update, :insert_or_update!]
+  @repo_update_operations [:update, :update!, :update_all]
+  @repo_delete_operations [:delete, :delete!, :delete_all]
+  @repo_write_operations @repo_insert_operations ++
+                           @repo_update_operations ++ @repo_delete_operations
+
   def parse(ast) do
     traverse_ast(ast, &detect_dangers/1)
   end
@@ -180,23 +186,20 @@ defmodule ExcellentMigrations.AstParser do
 
   defp detect_check_constraint(_), do: []
 
-  defp detect_records_modified({:., location, [{:__aliases__, _, modules}, operation]}) do
+  defp detect_records_modified({:., location, [{:__aliases__, _, modules}, operation]})
+       when operation in @repo_write_operations do
     if Enum.member?(modules, :Repo) do
-      danger =
-        operation
-        |> Atom.to_string()
-        |> String.replace_suffix("!", "")
-        |> String.replace_suffix("_all", "")
-        |> (&"operation_#{&1}").()
-        |> String.to_atom()
-
-      [{danger, Keyword.get(location, :line)}]
+      [{danger_type(operation), Keyword.get(location, :line)}]
     else
       []
     end
   end
 
   defp detect_records_modified(_), do: []
+
+  defp danger_type(op) when op in @repo_insert_operations, do: :operation_insert
+  defp danger_type(op) when op in @repo_update_operations, do: :operation_update
+  defp danger_type(op) when op in @repo_delete_operations, do: :operation_delete
 
   defp detect_column_added_with_default_inner({fun_name, location, [_, _, options]})
        when fun_name in [:add, :add_if_not_exists] do

--- a/test/ast_parser_test.exs
+++ b/test/ast_parser_test.exs
@@ -121,11 +121,38 @@ defmodule ExcellentMigrations.AstParserTest do
         |> Repo.update!()
       """)
 
+    ast6 = string_to_ast("Repo.insert_or_update!(changeset)")
+
     assert [operation_insert: 3] == AstParser.parse(ast1)
     assert [operation_insert: 1] == AstParser.parse(ast2)
     assert [operation_update: 1] == AstParser.parse(ast3)
     assert [operation_delete: 1] == AstParser.parse(ast4)
     assert [operation_update: 5] == AstParser.parse(ast5)
+    assert [operation_insert: 1] == AstParser.parse(ast6)
+  end
+
+  test "does not flag read-only Repo operations" do
+    ast1 = string_to_ast("Repo.one(query)")
+    ast2 = string_to_ast("Repo.one!(query)")
+    ast3 = string_to_ast("Repo.all(query)")
+    ast4 = string_to_ast("Repo.get(User, id)")
+    ast5 = string_to_ast("Repo.get!(User, id)")
+    ast6 = string_to_ast("Repo.get_by(User, email: email)")
+    ast7 = string_to_ast("Repo.query(sql)")
+    ast8 = string_to_ast("Repo.query!(sql)")
+    ast9 = string_to_ast("Repo.aggregate(query, :count)")
+    ast10 = string_to_ast("Repo.exists?(query)")
+
+    assert [] == AstParser.parse(ast1)
+    assert [] == AstParser.parse(ast2)
+    assert [] == AstParser.parse(ast3)
+    assert [] == AstParser.parse(ast4)
+    assert [] == AstParser.parse(ast5)
+    assert [] == AstParser.parse(ast6)
+    assert [] == AstParser.parse(ast7)
+    assert [] == AstParser.parse(ast8)
+    assert [] == AstParser.parse(ast9)
+    assert [] == AstParser.parse(ast10)
   end
 
   test "detects danger and safety assured" do


### PR DESCRIPTION
It took me a while to figure out how to resolve these error messages since these items weren't on the list: 

```
05:26:55.348 [warning] Operation query in path/to/migration/file.exs:10
05:27:42.593 [warning] Operation one in path/to/migration/file.exs:8
```