### PR TITLE
Bugfix: Properly warn of danger for column_reference_added when options provided as 3rd arg

### DIFF
--- a/lib/ast_parser.ex
+++ b/lib/ast_parser.ex
@@ -2,6 +2,7 @@ defmodule ExcellentMigrations.AstParser do
   @moduledoc false
   @max_columns_for_index 3
 
+  @add_functions [:add, :add_if_not_exists]
   @index_functions [:create, :create_if_not_exists, :drop, :drop_if_exists]
   @index_types [:index, :unique_index]
 
@@ -120,7 +121,7 @@ defmodule ExcellentMigrations.AstParser do
          {:alter, _,
           [{:table, _, _}, [do: {fun_name, location, [_, _, [default: {:fragment, _, _}]]}]]}
        )
-       when fun_name in [:add, :add_if_not_exists] do
+       when fun_name in @add_functions do
     [{:column_volatile_default, Keyword.get(location, :line)}]
   end
 
@@ -133,7 +134,7 @@ defmodule ExcellentMigrations.AstParser do
   defp detect_column_reference_added(
          {fun_name, location, [_, {:references, _, [_column, options]} | _]}
        )
-       when fun_name in [:add, :add_if_not_exists] do
+       when fun_name in @add_functions do
     if Keyword.get(options, :validate) == false do
       []
     else
@@ -142,7 +143,7 @@ defmodule ExcellentMigrations.AstParser do
   end
 
   defp detect_column_reference_added({fun_name, location, [_, {:references, _, _} | _]})
-       when fun_name in [:add, :add_if_not_exists] do
+       when fun_name in @add_functions do
     [{:column_reference_added, Keyword.get(location, :line)}]
   end
 
@@ -169,7 +170,7 @@ defmodule ExcellentMigrations.AstParser do
   defp detect_not_null_added(_), do: []
 
   defp detect_json_column_added({fun_name, location, [_, :json | _]})
-       when fun_name in [:add, :add_if_not_exists] do
+       when fun_name in @add_functions do
     [{:json_column_added, Keyword.get(location, :line)}]
   end
 
@@ -200,7 +201,7 @@ defmodule ExcellentMigrations.AstParser do
   defp detect_records_modified(_), do: []
 
   defp detect_column_added_with_default_inner({fun_name, location, [_, _, options]})
-       when fun_name in [:add, :add_if_not_exists] do
+       when fun_name in @add_functions do
     if Keyword.has_key?(options, :default) do
       [{:column_added_with_default, Keyword.get(location, :line)}]
     else

--- a/lib/ast_parser.ex
+++ b/lib/ast_parser.ex
@@ -130,15 +130,9 @@ defmodule ExcellentMigrations.AstParser do
   defp detect_column_volatile_default(_), do: []
 
   defp detect_column_reference_added(
-         {:modify, location, [_, {:references, _, _}, [from: {:references, _, _}]]}
-       ) do
-    [{:column_reference_added, Keyword.get(location, :line)}]
-  end
-
-  defp detect_column_reference_added(
-         {fun_name, location, [_, {:references, _, [_column, options]}]}
+         {fun_name, location, [_, {:references, _, [_column, options]} | _]}
        )
-       when fun_name in [:add, :modify] do
+       when fun_name in [:add, :add_if_not_exists] do
     if Keyword.get(options, :validate) == false do
       []
     else
@@ -146,8 +140,8 @@ defmodule ExcellentMigrations.AstParser do
     end
   end
 
-  defp detect_column_reference_added({fun_name, location, [_, {:references, _, _}]})
-       when fun_name in [:add, :modify] do
+  defp detect_column_reference_added({fun_name, location, [_, {:references, _, _} | _]})
+       when fun_name in [:add, :add_if_not_exists] do
     [{:column_reference_added, Keyword.get(location, :line)}]
   end
 
@@ -155,7 +149,9 @@ defmodule ExcellentMigrations.AstParser do
     [{:column_type_changed, Keyword.get(location, :line)}]
   end
 
-  defp detect_column_reference_added(_), do: []
+  defp detect_column_reference_added(_) do
+    []
+  end
 
   defp detect_not_null_added({:modify, location, [_, _, options]}) do
     if Keyword.get(options, :null) == false do

--- a/lib/ast_parser.ex
+++ b/lib/ast_parser.ex
@@ -31,6 +31,7 @@ defmodule ExcellentMigrations.AstParser do
       detect_column_added_with_default(code_part) ++
       detect_column_volatile_default(code_part) ++
       detect_column_reference_added(code_part) ++
+      detect_column_type_changed(code_part) ++
       detect_not_null_added(code_part) ++
       detect_check_constraint(code_part) ++
       detect_records_modified(code_part) ++
@@ -145,11 +146,15 @@ defmodule ExcellentMigrations.AstParser do
     [{:column_reference_added, Keyword.get(location, :line)}]
   end
 
-  defp detect_column_reference_added({:modify, location, _}) do
+  defp detect_column_reference_added(_) do
+    []
+  end
+
+  defp detect_column_type_changed({:modify, location, _}) do
     [{:column_type_changed, Keyword.get(location, :line)}]
   end
 
-  defp detect_column_reference_added(_) do
+  defp detect_column_type_changed(_) do
     []
   end
 

--- a/test/example_migrations/20191026103001_create_table_and_index.exs
+++ b/test/example_migrations/20191026103001_create_table_and_index.exs
@@ -1,7 +1,7 @@
 defmodule ExcellentMigrations.CreateDumplings do
   def change do
     create table(:dumplings) do
-      add(:dough, references(:dough_id, on_delete: :delete_all), null: false)
+      add(:dough, references(:dough_id, on_delete: :delete_all, validate: false), null: false)
       add(:size, :integer, null: false, default: 0)
     end
 

--- a/test/example_migrations/20250125010100_add_a_reference_column.exs
+++ b/test/example_migrations/20250125010100_add_a_reference_column.exs
@@ -1,0 +1,7 @@
+defmodule ExcellentMigrations.AddAReferenceColumn do
+  def change do
+    alter table(:dumplings) do
+      add(:vegetable_id, references(:vegetables, on_delete: :delete_all), null: true)
+    end
+  end
+end

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -24,7 +24,8 @@ defmodule ExcellentMigrations.RunnerTest do
       "test/example_migrations/20220725111501_create_unique_index.exs",
       "test/example_migrations/20220726010151_create_index_concurrently_invalid.exs",
       "test/example_migrations/20220804010152_create_index_concurrently_without_disable_ddl_transaction.exs",
-      "test/example_migrations/20220804010153_create_index_concurrently_without_disable_migration_lock.exs"
+      "test/example_migrations/20220804010153_create_index_concurrently_without_disable_migration_lock.exs",
+      "test/example_migrations/20250125010100_add_a_reference_column.exs"
     ]
 
     assert {
@@ -133,6 +134,11 @@ defmodule ExcellentMigrations.RunnerTest do
                  path:
                    "test/example_migrations/20220804010153_create_index_concurrently_without_disable_migration_lock.exs",
                  type: :index_concurrently_without_disable_migration_lock
+               },
+               %{
+                 line: 4,
+                 path: "test/example_migrations/20250125010100_add_a_reference_column.exs",
+                 type: :column_reference_added
                }
              ]
            } == Runner.check_migrations(migrations_paths: file_paths)


### PR DESCRIPTION
The current check for when a reference is being added with `:add` or `:add_if_existing` doesn't guard for when options are provided as the 3rd argument. This PR fixes the second case below to properly warn of danger.

**WARNS OF DANGER ✅**

```elixir
def change do
  alter table("recipes") do
    add :cookbook_id, references("cookbooks")
  end
end
```

**DOES NOT WARN OF DANGER ❌**

```elixir
def change do
  alter table("recipes") do
    add :cookbook_id, references("cookbooks"), null: true
  end
end
```