### PR TITLE
feat: add check for `:string` column type

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Postgres-specific checks:
 - [Adding a reference](#adding-a-reference)
 - [Adding an index non-concurrently](#adding-an-index-non-concurrently)
 - [Adding an index concurrently without disabling lock or transaction](#adding-an-index-concurrently-without-disabling-lock-or-transaction)
+- [Adding a string column](#adding-a-string-column)
 
 Best practices:
 
@@ -708,6 +709,36 @@ def change do
   end
 end
 ```
+
+---
+
+### Adding a string column
+
+In Postgres, there is no performance benefit to using the `:string` (`varchar(255)`) type over `:text`, and `:string` can cause failures when inserting data if the value is longer than 255 characters.
+
+**BAD ❌**
+
+```elixir
+def change do
+  alter table("recipes") do
+    add :name, :string
+  end
+end
+```
+
+**GOOD ✅**
+
+Use `:text` instead
+
+```elixir
+def change do
+  alter table("recipes") do
+    add :name, :text
+  end
+end
+```
+
+Reference: [Postgres Official Anti-Patterns Doc](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_varchar.28n.29_by_default)
 
 ---
 

--- a/test/ast_parser_test.exs
+++ b/test/ast_parser_test.exs
@@ -267,19 +267,38 @@ defmodule ExcellentMigrations.AstParserTest do
     alter_table =
       string_to_ast("""
       alter table("recipes") do
-        add(:taste, :string, default: "sweet")
+        add(:taste, :text, default: "sweet")
       end
       """)
 
     create_table =
       string_to_ast("""
       create table("recipes") do
-        add(:taste, :string, default: "sweet")
+        add(:taste, :text, default: "sweet")
       end
       """)
 
     assert [column_added_with_default: 2] == AstParser.parse(alter_table)
     assert [] == AstParser.parse(create_table)
+  end
+
+  test "detects column added with string type" do
+    alter_table =
+      string_to_ast("""
+      alter table("recipes") do
+        add(:taste, :string)
+      end
+      """)
+
+    create_table =
+      string_to_ast("""
+      create table("recipes") do
+        add(:taste, :string, null: true)
+      end
+      """)
+
+    assert [column_added_with_string_type: 2] == AstParser.parse(alter_table)
+    assert [column_added_with_string_type: 2] == AstParser.parse(create_table)
   end
 
   test "detects column default changed to volatile" do
@@ -328,7 +347,7 @@ defmodule ExcellentMigrations.AstParserTest do
     ast =
       string_to_ast("""
       alter table("recipes") do
-        add_if_not_exists(:taste, :string, default: "sweet")
+        add_if_not_exists(:taste, :text, default: "sweet")
       end
       """)
 

--- a/test/example_migrations/20191026103007_add_column_with_default_value.exs
+++ b/test/example_migrations/20191026103007_add_column_with_default_value.exs
@@ -1,8 +1,8 @@
 defmodule ExcellentMigrations.AddTasteToDumplingsWithDefault do
   def change do
     alter table("dumplings") do
-      add(:taste, :string, default: "sweet")
-      add(:size, :string, default: "big")
+      add(:taste, :text, default: "sweet")
+      add(:size, :text, default: "big")
     end
   end
 end

--- a/test/example_migrations/20250228103004_add_column_with_string_type.exs
+++ b/test/example_migrations/20250228103004_add_column_with_string_type.exs
@@ -1,0 +1,8 @@
+defmodule ExcellentMigrations.AddKindToFruitsWithStringType do
+  def change do
+    alter table("fruits") do
+      add(:kind, :string)
+      add(:size, :string, null: true)
+    end
+  end
+end

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -24,7 +24,8 @@ defmodule ExcellentMigrations.RunnerTest do
       "test/example_migrations/20220725111501_create_unique_index.exs",
       "test/example_migrations/20220726010151_create_index_concurrently_invalid.exs",
       "test/example_migrations/20220804010152_create_index_concurrently_without_disable_ddl_transaction.exs",
-      "test/example_migrations/20220804010153_create_index_concurrently_without_disable_migration_lock.exs"
+      "test/example_migrations/20220804010153_create_index_concurrently_without_disable_migration_lock.exs",
+      "test/example_migrations/20250228103004_add_column_with_string_type.exs"
     ]
 
     assert {
@@ -133,6 +134,16 @@ defmodule ExcellentMigrations.RunnerTest do
                  path:
                    "test/example_migrations/20220804010153_create_index_concurrently_without_disable_migration_lock.exs",
                  type: :index_concurrently_without_disable_migration_lock
+               },
+               %{
+                 line: 4,
+                 path: "test/example_migrations/20250228103004_add_column_with_string_type.exs",
+                 type: :column_added_with_string_type
+               },
+               %{
+                 line: 5,
+                 path: "test/example_migrations/20250228103004_add_column_with_string_type.exs",
+                 type: :column_added_with_string_type
                }
              ]
            } == Runner.check_migrations(migrations_paths: file_paths)


### PR DESCRIPTION
# Motivation

In Postgres, it is recommended to use `:text` data type over `:string` (`varchar(255)`) by default, and only opt in to limited varchar when there's a real need for it. The limit does not provide much benefit, and it can cause failures when inserting data.

This is documented in the official Postgres Anti Patterns doc: https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_varchar.28n.29_by_default

Our team has bumped into this a few times now, and migrating a field from
`:string` to `:text` can in some cases cause downtime, so we consider this now a
best practice to use text by default.

# Changes

- Introduce a check for new columns being added with a type of `:string`
- I had to change a few existing tests that used `:string` in the examples
- Add docs and tests