### PR TITLE
Fix GitHub Actions workflow config

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -19,7 +19,7 @@ jobs:
       uses: erlef/setup-beam@v1
       with:
         elixir-version: '1.12.3'
-        otp-version: '24.1'
+        otp-version: '24.3'
     - name: Restore dependencies cache
       uses: actions/cache@v4
       with:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -5,22 +5,23 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   build:
-
     name: Build and test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Elixir
-      uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
+      uses: erlef/setup-beam@v1
       with:
-        elixir-version: '1.12.3' # Define the elixir version [required]
-        otp-version: '24.1' # Define the OTP version [required]
+        elixir-version: '1.12.3'
+        otp-version: '24.1'
     - name: Restore dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: deps
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}


### PR DESCRIPTION
- Upgrade action versions (checkout@v4, setup-beam@v1, cache@v4)
- Update runner to ubuntu-24.04 with 30min timeout (we had a 1 day timeout)
- Add workflow_dispatch trigger so one can manually trigger CI
- Maintain existing Elixir 1.12.3 version, bump OTP version from OTP 24.1 to 24.3 for setup-beam support

<img width="1462" height="803" alt="image" src="https://github.com/user-attachments/assets/900056de-9fe5-455b-a861-ae736bd49ddc" />

Previous workflow issues:

<img width="915" height="511" alt="image" src="https://github.com/user-attachments/assets/bf678656-8cd7-4638-9348-0373ab06fd94" />
<img width="915" height="776" alt="image" src="https://github.com/user-attachments/assets/c2a0e4f9-ca8a-4e78-adb7-45529879246a" />
