### PR TITLE
Improve reference detection

### DIFF
--- a/lib/ast_parser.ex
+++ b/lib/ast_parser.ex
@@ -136,15 +136,16 @@ defmodule ExcellentMigrations.AstParser do
 
   defp detect_column_type_changed(_), do: []
 
-  defp detect_column_reference_added(
-         {:modify, location, [_, {:references, _, _}, [from: {:references, _, _}]]}
-       ) do
-    [{:column_reference_added, Keyword.get(location, :line)}]
+  defp detect_column_reference_added({fun_name, location, [_, {:references, _, [_, options]}]})
+       when fun_name in [:add, :modify] do
+    if Keyword.get(options, :validate) == false do
+      []
+    else
+      [{:column_reference_added, Keyword.get(location, :line)}]
+    end
   end
 
-  defp detect_column_reference_added(
-         {fun_name, location, [_, {:references, _, [_column, options]}]}
-       )
+  defp detect_column_reference_added({fun_name, location, [_, {:references, _, [_, options]}, _]})
        when fun_name in [:add, :modify] do
     if Keyword.get(options, :validate) == false do
       []
@@ -154,6 +155,11 @@ defmodule ExcellentMigrations.AstParser do
   end
 
   defp detect_column_reference_added({fun_name, location, [_, {:references, _, _}]})
+       when fun_name in [:add, :modify] do
+    [{:column_reference_added, Keyword.get(location, :line)}]
+  end
+
+  defp detect_column_reference_added({fun_name, location, [_, {:references, _, _}, _]})
        when fun_name in [:add, :modify] do
     [{:column_reference_added, Keyword.get(location, :line)}]
   end

--- a/lib/ast_parser.ex
+++ b/lib/ast_parser.ex
@@ -30,6 +30,7 @@ defmodule ExcellentMigrations.AstParser do
       detect_column_renamed(code_part) ++
       detect_column_added_with_default(code_part) ++
       detect_column_volatile_default(code_part) ++
+      detect_column_type_changed(code_part) ++
       detect_column_reference_added(code_part) ++
       detect_not_null_added(code_part) ++
       detect_check_constraint(code_part) ++
@@ -129,6 +130,12 @@ defmodule ExcellentMigrations.AstParser do
 
   defp detect_column_volatile_default(_), do: []
 
+  defp detect_column_type_changed({:modify, location, _}) do
+    [{:column_type_changed, Keyword.get(location, :line)}]
+  end
+
+  defp detect_column_type_changed(_), do: []
+
   defp detect_column_reference_added(
          {:modify, location, [_, {:references, _, _}, [from: {:references, _, _}]]}
        ) do
@@ -149,10 +156,6 @@ defmodule ExcellentMigrations.AstParser do
   defp detect_column_reference_added({fun_name, location, [_, {:references, _, _}]})
        when fun_name in [:add, :modify] do
     [{:column_reference_added, Keyword.get(location, :line)}]
-  end
-
-  defp detect_column_reference_added({:modify, location, _}) do
-    [{:column_type_changed, Keyword.get(location, :line)}]
   end
 
   defp detect_column_reference_added(_), do: []

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -31,6 +31,11 @@ defmodule ExcellentMigrations.RunnerTest do
              :dangerous,
              [
                %{
+                 line: 4,
+                 type: :column_reference_added,
+                 path: "test/example_migrations/20191026103001_create_table_and_index.exs"
+               },
+               %{
                  line: 8,
                  path: "test/example_migrations/20191026103001_create_table_and_index.exs",
                  type: :index_not_concurrently


### PR DESCRIPTION
Improve detection of references or foreign keys

**Changes:**
- Unify `add` and `modify` operations – both now handled consistently in reference detection
- Detect `references` with and without optional parameters
- Always flag `modify` as `column_type_changed` – `modify` always requires specifying column type, but current column type in DB is unknown, so it can potentially change column type.