### PR TITLE
DateTime parsing and comparison on migrations timestamps and `:start_after`

### DIFF
--- a/lib/credo_check/migrations_safety.ex
+++ b/lib/credo_check/migrations_safety.ex
@@ -21,7 +21,10 @@ if Code.ensure_loaded?(Credo.Check) do
 
     @doc false
     def run(source_file, params \\ []) do
-      start_after = Application.get_env(:excellent_migrations, :start_after)
+      start_after =
+        :excellent_migrations
+        |> Application.get_env(:start_after)
+        |> FilesFinder.timestamp_str_to_datetime() || DateTime.from_unix!(0)
 
       if FilesFinder.relevant_file?(source_file.filename, start_after) do
         detect_dangers(source_file, params)

--- a/lib/files_finder.ex
+++ b/lib/files_finder.ex
@@ -1,25 +1,149 @@
 defmodule ExcellentMigrations.FilesFinder do
-  @moduledoc false
+  @moduledoc """
+  Migration files utility module responsible for finding relevant migration files and extracting timestamps from their paths.
+  """
 
+  @doc """
+  Finds all relevant migration files in the project.
+
+  Searches for files matching `**/migrations/*.exs` and filters them based on:
+  - The `:start_after` configuration from application environment
+  - Exclusion of `deps/` and `_build/` directories
+
+  """
+  @spec get_migrations_paths() :: [String.t()]
   def get_migrations_paths do
-    start_after = Application.get_env(:excellent_migrations, :start_after)
+    start_after =
+      :excellent_migrations
+      |> Application.get_env(:start_after)
+      |> timestamp_str_to_datetime() || DateTime.from_unix!(0)
 
     "**/migrations/*.exs"
     |> Path.wildcard()
     |> Enum.filter(&relevant_file?(&1, start_after))
   end
 
+  @doc """
+  Determines if a file path is relevant for analysis.
+
+  A file is considered relevant if all of the following are true:
+  - The path does not start with `deps/` or `_build/`
+  - The path does not contain `/deps/` or `/_build/` anywhere
+  - The path contains `migrations/`
+  - The migration timestamp is greater than `start_after`
+
+  ## Parameters
+
+    * `path` - The file path to check
+    * `start_after` - A DateTime representing the cutoff timestamp
+
+  ## Examples
+
+      iex> start_after = DateTime.from_unix!(1_572_085_800)
+      iex> ExcellentMigrations.FilesFinder.relevant_file?(
+      ...>   "priv/repo/migrations/20191026103003_create_table.exs",
+      ...>   start_after
+      ...> )
+      true
+
+      iex> start_after = DateTime.from_unix!(1_572_085_800)
+      iex> ExcellentMigrations.FilesFinder.relevant_file?(
+      ...>   "deps/my_dep/migrations/20191026103003_create_table.exs",
+      ...>   start_after
+      ...> )
+      false
+
+      iex> start_after = DateTime.from_unix!(1_572_085_800)
+      iex> ExcellentMigrations.FilesFinder.relevant_file?(
+      ...>   "priv/repo/other/20191026103003_create_table.exs",
+      ...>   start_after
+      ...> )
+      false
+
+  """
+  @spec relevant_file?(String.t(), DateTime.t()) :: boolean
   def relevant_file?(path, start_after) do
+    migration_dt = migration_timestamp(path)
+
     !String.starts_with?(path, ["deps/", "_build/"]) &&
       !String.contains?(path, ["/deps/", "/_build/"]) &&
       String.contains?(path, "migrations/") &&
-      migration_timestamp(path) > start_after
+      DateTime.compare(migration_dt, start_after) == :gt
   end
 
-  defp migration_timestamp(path) do
+  @doc """
+  Extracts the timestamp from a migration file path.
+
+  Parses the migration filename to extract the timestamp prefix (expected to be in
+  the format `YYYYMMDDHHMMSS`). If the timestamp cannot be parsed, returns
+  `DateTime.from_unix!(1)` as a fallback.
+
+  ## Parameters
+
+    * `path` - The migration file path
+
+  ## Examples
+
+      iex> ExcellentMigrations.FilesFinder.migration_timestamp(
+      ...>   "priv/repo/migrations/20191026103002_execute_raw_sql.exs"
+      ...> )
+      ~U[2019-10-26 10:30:02Z]
+
+      iex> ExcellentMigrations.FilesFinder.migration_timestamp(
+      ...>   "migrations/invalid_migration.exs"
+      ...> )
+      ~U[1970-01-01 00:00:01Z]
+
+      iex> ExcellentMigrations.FilesFinder.migration_timestamp("")
+      ~U[1970-01-01 00:00:01Z]
+
+  """
+  @spec migration_timestamp(String.t()) :: DateTime.t()
+  def migration_timestamp(path) do
     path
     |> Path.basename()
     |> String.split("_")
     |> hd()
+    |> timestamp_str_to_datetime() || DateTime.from_unix!(1)
+  end
+
+  @doc """
+  Converts a timestamp string to a DateTime.
+
+  Expects a string in the format `YYYYMMDDHHMMSS` (14 characters representing
+  year, month, day, hour, minute, and second). Returns `nil` if the string
+  doesn't match the expected format or represents an invalid date.
+
+  ## Parameters
+
+    * `timestamp_str` - A 14-character timestamp string
+
+  ## Examples
+
+      iex> ExcellentMigrations.FilesFinder.timestamp_str_to_datetime("20191026103002")
+      ~U[2019-10-26 10:30:02Z]
+
+      iex> ExcellentMigrations.FilesFinder.timestamp_str_to_datetime("invalid")
+      nil
+
+      iex> ExcellentMigrations.FilesFinder.timestamp_str_to_datetime("")
+      nil
+
+      iex> ExcellentMigrations.FilesFinder.timestamp_str_to_datetime(nil)
+      nil
+
+      iex> ExcellentMigrations.FilesFinder.timestamp_str_to_datetime("20190230120000")
+      nil
+
+  """
+  @spec timestamp_str_to_datetime(String.t() | nil) :: DateTime.t() | nil
+  def timestamp_str_to_datetime(timestamp_str) do
+    with <<yyyy::binary-size(4), mo::binary-size(2), dd::binary-size(2), hh::binary-size(2),
+           mi::binary-size(2), ss::binary-size(2)>> <- timestamp_str,
+         {:ok, dt, 0} <- DateTime.from_iso8601("#{yyyy}#{mo}#{dd}T#{hh}#{mi}#{ss}Z", :basic) do
+      dt
+    else
+      _ -> nil
+    end
   end
 end

--- a/test/dangers_detector_test.exs
+++ b/test/dangers_detector_test.exs
@@ -1,5 +1,6 @@
 defmodule ExcellentMigrations.DangersDetectorTest do
   use ExUnit.Case
+  import ExUnit.CaptureLog
   alias ExcellentMigrations.DangersDetector
 
   test "detects dangers in AST" do
@@ -13,7 +14,7 @@ defmodule ExcellentMigrations.DangersDetectorTest do
     {ast, source_code} =
       get_ast_and_source("20191026103004_execute_raw_sql_with_safety_assured.exs")
 
-    assert [] == DangersDetector.detect_dangers(ast, source_code)
+    assert {[], _log} = with_log(fn -> DangersDetector.detect_dangers(ast, source_code) end)
   end
 
   test "skips dangers with safety assured config comments" do

--- a/test/dangers_filter_test.exs
+++ b/test/dangers_filter_test.exs
@@ -1,5 +1,6 @@
 defmodule ExcellentMigrations.DangersFilterTest do
   use ExUnit.Case
+  import ExUnit.CaptureLog
   alias ExcellentMigrations.DangersFilter
 
   describe "no safety assured" do
@@ -59,83 +60,91 @@ defmodule ExcellentMigrations.DangersFilterTest do
 
   describe "safety assured via module attribute" do
     test "rejects all if safety assured module attribute for all" do
-      assert [] ==
-               DangersFilter.filter_dangers(
-                 [table_renamed: 5, safety_assured: :all],
-                 [],
-                 []
-               )
+      capture_log(fn ->
+        assert [] ==
+                 DangersFilter.filter_dangers(
+                   [table_renamed: 5, safety_assured: :all],
+                   [],
+                   []
+                 )
 
-      assert [] ==
-               DangersFilter.filter_dangers(
-                 [table_renamed: 5, column_renamed: 8, safety_assured: :all],
-                 [],
-                 []
-               )
+        assert [] ==
+                 DangersFilter.filter_dangers(
+                   [table_renamed: 5, column_renamed: 8, safety_assured: :all],
+                   [],
+                   []
+                 )
+      end)
     end
 
     test "rejects only types that have safety assured module attribute" do
-      assert [table_renamed: 5] ==
-               DangersFilter.filter_dangers(
-                 [table_renamed: 5, column_renamed: 8, safety_assured: [:column_renamed]],
-                 [],
-                 []
-               )
+      capture_log(fn ->
+        assert [table_renamed: 5] ==
+                 DangersFilter.filter_dangers(
+                   [table_renamed: 5, column_renamed: 8, safety_assured: [:column_renamed]],
+                   [],
+                   []
+                 )
 
-      assert [] ==
-               DangersFilter.filter_dangers(
-                 [column_renamed: 8, safety_assured: [:column_renamed]],
-                 [],
-                 []
-               )
+        assert [] ==
+                 DangersFilter.filter_dangers(
+                   [column_renamed: 8, safety_assured: [:column_renamed]],
+                   [],
+                   []
+                 )
 
-      assert [] ==
-               DangersFilter.filter_dangers(
-                 [
-                   table_renamed: 5,
-                   column_renamed: 8,
-                   safety_assured: [:table_renamed, :column_renamed]
-                 ],
-                 [],
-                 []
-               )
+        assert [] ==
+                 DangersFilter.filter_dangers(
+                   [
+                     table_renamed: 5,
+                     column_renamed: 8,
+                     safety_assured: [:table_renamed, :column_renamed]
+                   ],
+                   [],
+                   []
+                 )
+      end)
     end
 
     test "rejects types from multiple safety_assured module attribute" do
-      assert [column_removed: 11] ==
-               DangersFilter.filter_dangers(
-                 [
-                   table_renamed: 5,
-                   column_renamed: 8,
-                   column_renamed: 10,
-                   column_removed: 11,
-                   safety_assured: [:column_renamed],
-                   safety_assured: [:table_renamed]
-                 ],
-                 [],
-                 []
-               )
+      capture_log(fn ->
+        assert [column_removed: 11] ==
+                 DangersFilter.filter_dangers(
+                   [
+                     table_renamed: 5,
+                     column_renamed: 8,
+                     column_renamed: 10,
+                     column_removed: 11,
+                     safety_assured: [:column_renamed],
+                     safety_assured: [:table_renamed]
+                   ],
+                   [],
+                   []
+                 )
+      end)
     end
 
     test "module attribute safety_assured: :all is ignored if there are specific types listed" do
-      assert [table_renamed: 5] ==
-               DangersFilter.filter_dangers(
-                 [table_renamed: 5, column_renamed: 8, safety_assured: [:all, :column_renamed]],
-                 [],
-                 []
-               )
+      capture_log(fn ->
+        assert [table_renamed: 5] ==
+                 DangersFilter.filter_dangers(
+                   [table_renamed: 5, column_renamed: 8, safety_assured: [:all, :column_renamed]],
+                   [],
+                   []
+                 )
 
-      assert [table_renamed: 5] ==
-               DangersFilter.filter_dangers(
-                 [
-                   table_renamed: 5,
-                   column_renamed: 8,
-                   safety_assured: [:all],
-                   safety_assured: [:column_renamed]
-                 ],
-                 [],
-                 []
-               )
+        assert [table_renamed: 5] ==
+                 DangersFilter.filter_dangers(
+                   [
+                     table_renamed: 5,
+                     column_renamed: 8,
+                     safety_assured: [:all],
+                     safety_assured: [:column_renamed]
+                   ],
+                   [],
+                   []
+                 )
+      end)
     end
   end
 end

--- a/test/files_finder_test.exs
+++ b/test/files_finder_test.exs
@@ -1,0 +1,5 @@
+defmodule ExcellentMigrations.FilesFinderTest do
+  use ExUnit.Case, async: true
+
+  doctest ExcellentMigrations.FilesFinder
+end

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -1,5 +1,6 @@
 defmodule ExcellentMigrations.RunnerTest do
   use ExUnit.Case
+  import ExUnit.CaptureLog
   alias ExcellentMigrations.Runner
 
   test "it should be valid migration files" do
@@ -27,120 +28,122 @@ defmodule ExcellentMigrations.RunnerTest do
       "test/example_migrations/20220804010153_create_index_concurrently_without_disable_migration_lock.exs"
     ]
 
-    assert {
-             :dangerous,
-             [
-               %{
-                 line: 4,
-                 type: :column_reference_added,
-                 path: "test/example_migrations/20191026103001_create_table_and_index.exs"
-               },
-               %{
-                 line: 8,
-                 path: "test/example_migrations/20191026103001_create_table_and_index.exs",
-                 type: :index_not_concurrently
-               },
-               %{
-                 line: 3,
-                 path: "test/example_migrations/20191026103002_execute_raw_sql.exs",
-                 type: :raw_sql_executed
-               },
-               %{
-                 line: 7,
-                 path: "test/example_migrations/20191026103002_execute_raw_sql.exs",
-                 type: :raw_sql_executed
-               },
-               %{
-                 line: 4,
-                 path: "test/example_migrations/20191026103005_remove_column.exs",
-                 type: :column_removed
-               },
-               %{
-                 line: 3,
-                 path: "test/example_migrations/20191026103006_rename_table.exs",
-                 type: :table_renamed
-               },
-               %{
-                 line: 4,
-                 path: "test/example_migrations/20191026103007_add_column_with_default_value.exs",
-                 type: :column_added_with_default
-               },
-               %{
-                 line: 5,
-                 path: "test/example_migrations/20191026103007_add_column_with_default_value.exs",
-                 type: :column_added_with_default
-               },
-               %{
-                 line: 4,
-                 path: "test/example_migrations/20191026103008_change_column_type.exs",
-                 type: :column_type_changed
-               },
-               %{
-                 line: 3,
-                 path: "test/example_migrations/20220725111000_create_index.exs",
-                 type: :index_not_concurrently
-               },
-               %{
-                 line: 4,
-                 path: "test/example_migrations/20220725111000_create_index.exs",
-                 type: :index_not_concurrently
-               },
-               %{
-                 line: 8,
-                 path: "test/example_migrations/20220725111000_create_index.exs",
-                 type: :index_not_concurrently
-               },
-               %{
-                 line: 9,
-                 path: "test/example_migrations/20220725111000_create_index.exs",
-                 type: :index_not_concurrently
-               },
-               %{
-                 line: 3,
-                 path: "test/example_migrations/20220725111501_create_unique_index.exs",
-                 type: :index_not_concurrently
-               },
-               %{
-                 line: 4,
-                 path: "test/example_migrations/20220725111501_create_unique_index.exs",
-                 type: :index_not_concurrently
-               },
-               %{
-                 line: 8,
-                 path: "test/example_migrations/20220725111501_create_unique_index.exs",
-                 type: :index_not_concurrently
-               },
-               %{
-                 line: 9,
-                 path: "test/example_migrations/20220725111501_create_unique_index.exs",
-                 type: :index_not_concurrently
-               },
-               %{
-                 line: 13,
-                 path:
-                   "test/example_migrations/20220726010151_create_index_concurrently_invalid.exs",
-                 type: :index_concurrently_without_disable_migration_lock
-               },
-               %{
-                 line: 13,
-                 path:
-                   "test/example_migrations/20220726010151_create_index_concurrently_invalid.exs",
-                 type: :index_concurrently_without_disable_ddl_transaction
-               },
-               %{
-                 line: 15,
-                 path:
-                   "test/example_migrations/20220804010152_create_index_concurrently_without_disable_ddl_transaction.exs",
-                 type: :index_concurrently_without_disable_ddl_transaction
-               },
-               %{
-                 line: 15,
-                 path:
-                   "test/example_migrations/20220804010153_create_index_concurrently_without_disable_migration_lock.exs",
-                 type: :index_concurrently_without_disable_migration_lock
-               }
-             ]
-           } == Runner.check_migrations(migrations_paths: file_paths)
+    assert {{
+              :dangerous,
+              [
+                %{
+                  line: 4,
+                  type: :column_reference_added,
+                  path: "test/example_migrations/20191026103001_create_table_and_index.exs"
+                },
+                %{
+                  line: 8,
+                  path: "test/example_migrations/20191026103001_create_table_and_index.exs",
+                  type: :index_not_concurrently
+                },
+                %{
+                  line: 3,
+                  path: "test/example_migrations/20191026103002_execute_raw_sql.exs",
+                  type: :raw_sql_executed
+                },
+                %{
+                  line: 7,
+                  path: "test/example_migrations/20191026103002_execute_raw_sql.exs",
+                  type: :raw_sql_executed
+                },
+                %{
+                  line: 4,
+                  path: "test/example_migrations/20191026103005_remove_column.exs",
+                  type: :column_removed
+                },
+                %{
+                  line: 3,
+                  path: "test/example_migrations/20191026103006_rename_table.exs",
+                  type: :table_renamed
+                },
+                %{
+                  line: 4,
+                  path:
+                    "test/example_migrations/20191026103007_add_column_with_default_value.exs",
+                  type: :column_added_with_default
+                },
+                %{
+                  line: 5,
+                  path:
+                    "test/example_migrations/20191026103007_add_column_with_default_value.exs",
+                  type: :column_added_with_default
+                },
+                %{
+                  line: 4,
+                  path: "test/example_migrations/20191026103008_change_column_type.exs",
+                  type: :column_type_changed
+                },
+                %{
+                  line: 3,
+                  path: "test/example_migrations/20220725111000_create_index.exs",
+                  type: :index_not_concurrently
+                },
+                %{
+                  line: 4,
+                  path: "test/example_migrations/20220725111000_create_index.exs",
+                  type: :index_not_concurrently
+                },
+                %{
+                  line: 8,
+                  path: "test/example_migrations/20220725111000_create_index.exs",
+                  type: :index_not_concurrently
+                },
+                %{
+                  line: 9,
+                  path: "test/example_migrations/20220725111000_create_index.exs",
+                  type: :index_not_concurrently
+                },
+                %{
+                  line: 3,
+                  path: "test/example_migrations/20220725111501_create_unique_index.exs",
+                  type: :index_not_concurrently
+                },
+                %{
+                  line: 4,
+                  path: "test/example_migrations/20220725111501_create_unique_index.exs",
+                  type: :index_not_concurrently
+                },
+                %{
+                  line: 8,
+                  path: "test/example_migrations/20220725111501_create_unique_index.exs",
+                  type: :index_not_concurrently
+                },
+                %{
+                  line: 9,
+                  path: "test/example_migrations/20220725111501_create_unique_index.exs",
+                  type: :index_not_concurrently
+                },
+                %{
+                  line: 13,
+                  path:
+                    "test/example_migrations/20220726010151_create_index_concurrently_invalid.exs",
+                  type: :index_concurrently_without_disable_migration_lock
+                },
+                %{
+                  line: 13,
+                  path:
+                    "test/example_migrations/20220726010151_create_index_concurrently_invalid.exs",
+                  type: :index_concurrently_without_disable_ddl_transaction
+                },
+                %{
+                  line: 15,
+                  path:
+                    "test/example_migrations/20220804010152_create_index_concurrently_without_disable_ddl_transaction.exs",
+                  type: :index_concurrently_without_disable_ddl_transaction
+                },
+                %{
+                  line: 15,
+                  path:
+                    "test/example_migrations/20220804010153_create_index_concurrently_without_disable_migration_lock.exs",
+                  type: :index_concurrently_without_disable_migration_lock
+                }
+              ]
+            }, _log} = with_log(fn -> Runner.check_migrations(migrations_paths: file_paths) end)
   end
 
   test "no dangerous operations" do
@@ -149,6 +152,7 @@ defmodule ExcellentMigrations.RunnerTest do
       "test/example_migrations/20191026103004_execute_raw_sql_with_safety_assured.exs"
     ]
 
-    assert :safe == Runner.check_migrations(migrations_paths: file_paths)
+    assert {:safe, _log} =
+             with_log(fn -> Runner.check_migrations(migrations_paths: file_paths) end)
   end
 end


### PR DESCRIPTION
## Motivation
```gherkin
Given `:start_after` is provided,
And a directory containing `migrations` in the name,
And a file without a timestamp-prefixed name,
Then this file is not relevant
```
Currently, the above file is filtered in as a result of the string comparison. 
The PR addresses this by using DateTime parsing and comparison on migration timestamps and the `:start_after` argument. And if it's not provided, then it defaults to exploring and checking any folder containing `migrations` in its name.

## Changes made
- Suppress `@safety_assured` warning on tests
- DateTime parsing and comparison on migrations timestamps and `:start_after`
- Add docs, specs, and tests to FilesFinder module